### PR TITLE
Removing ActiveRecord Migrations and Inheritance

### DIFF
--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -1,4 +1,4 @@
-class Download < ActiveRecord::Base
+class Download
   # attr_accessible :title, :body
 
 	#Isolates the dynamically geberated ComboFix URL from the download page by finding predicatable 

--- a/app/models/drive_op.rb
+++ b/app/models/drive_op.rb
@@ -1,4 +1,4 @@
-class DriveOp < ActiveRecord::Base
+class DriveOp
   # attr_accessible :title, :body
 
 	#Auto-mounts the customer drive by iterating through "mount_iterations", mounting them, then 

--- a/app/models/file_op.rb
+++ b/app/models/file_op.rb
@@ -1,4 +1,4 @@
-class FileOp < ActiveRecord::Base
+class FileOp
   # attr_accessible :title, :body
 
 	#Uses the system's "find" command to create a list of files maching the modified time given 

--- a/app/models/system_info.rb
+++ b/app/models/system_info.rb
@@ -1,4 +1,4 @@
-class SystemInfo < ActiveRecord::Base
+class SystemInfo
   
 	#Gets the system information for the desired attributes and returns them as an ordered array of strings
 	def self.get_system_stats

--- a/db/migrate/20130203200158_create_file_ops.rb
+++ b/db/migrate/20130203200158_create_file_ops.rb
@@ -1,8 +1,0 @@
-class CreateFileOps < ActiveRecord::Migration
-  def change
-    create_table :file_ops do |t|
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20130216231858_create_downloads.rb
+++ b/db/migrate/20130216231858_create_downloads.rb
@@ -1,8 +1,0 @@
-class CreateDownloads < ActiveRecord::Migration
-  def change
-    create_table :downloads do |t|
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20130225011044_create_system_infos.rb
+++ b/db/migrate/20130225011044_create_system_infos.rb
@@ -1,8 +1,0 @@
-class CreateSystemInfos < ActiveRecord::Migration
-  def change
-    create_table :system_infos do |t|
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20130316233247_create_drive_ops.rb
+++ b/db/migrate/20130316233247_create_drive_ops.rb
@@ -1,8 +1,0 @@
-class CreateDriveOps < ActiveRecord::Migration
-  def change
-    create_table :drive_ops do |t|
-
-      t.timestamps
-    end
-  end
-end


### PR DESCRIPTION
It doesn't appear that there's any database interaction going on... not inheriting from ActiveRecord::Base will reduce the size of the models and improve performance a bit. 
